### PR TITLE
Convert Linux build to building a .deb package (20201105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
       ]
     },
     "linux": {
+      "target": "deb",
+      "maintainer": "stephen_mcconnel@sil.org",
       "icon": "build/linux",
       "fileAssociations": [
         {
@@ -85,7 +87,8 @@
           "role": "Viewer"
         }
       ]
-    }
+    },
+    "deb": {}
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",


### PR DESCRIPTION
The default snap build crashes when trying to open the file dialog.
The deb build works okay as far as I can tell on both bionic and focal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloompub-viewer/6)
<!-- Reviewable:end -->
